### PR TITLE
Fix Netlify deployment issues and dynamic units implementation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,9 @@
 [build]
-  command = "npm run netlify-build"
+  command = "yarn build"
   publish = ".next"
 
 [build.environment]
   NODE_VERSION = "20"
-  NPM_FLAGS = "--legacy-peer-deps"
-  # Force npm usage and disable yarn
-  NPM_CONFIG_PREFER_OFFLINE = "false"
-  NPM_CONFIG_AUDIT = "false"
-  YARN_ENABLE = "false"
-  USE_NPM = "true"
-  DISABLE_YARN = "true"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "seed": "ts-node --esm scripts/seed.ts",
-    "seed:admin": "NODE_OPTIONS='--loader ts-node/esm' tsx scripts/seed-admin.ts",
-    "netlify-build": "rm -f yarn.lock && npm ci && npm run build"
+    "seed:admin": "NODE_OPTIONS='--loader ts-node/esm' tsx scripts/seed-admin.ts"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",

--- a/src/app/transactions/new/page.tsx
+++ b/src/app/transactions/new/page.tsx
@@ -26,7 +26,7 @@ interface Product {
   qty_per_box: number;
   barcode: string | null;
   qty: number;
-  units: string;
+  units?: string;
 }
 
 type UnitType = 'pcs' | 'rtg' | 'bal' | 'karton' | 'ikat' | 'slop';
@@ -751,7 +751,7 @@ export default function NewTransactionPage() {
                                 <p>Eceran: Rp{product.retail_price.toLocaleString('id-ID')}</p>
                                 {product.qty_per_box > 1 && (
                                   <p className="text-amber-600">
-                                    {getUnitDisplayName(product.units)}: Rp{product.retail_box_price.toLocaleString('id-ID')} ({product.qty_per_box} pcs)
+                                    {getUnitDisplayName(product.units || 'karton')}: Rp{product.retail_box_price.toLocaleString('id-ID')} ({product.qty_per_box} pcs)
                                   </p>
                                 )}
                                 {product.min_wholesale_qty > 0 && (
@@ -775,10 +775,10 @@ export default function NewTransactionPage() {
                                 <Button 
                                   size="sm" 
                                   variant="outline"
-                                  onClick={() => addToCart(product, product.units as UnitType)}
+                                  onClick={() => addToCart(product, (product.units || 'karton') as UnitType)}
                                   className="gap-1 text-xs px-2 py-1 h-7"
                                 >
-                                  <Package className="h-3 w-3" /> {getUnitDisplayName(product.units)}
+                                  <Package className="h-3 w-3" /> {getUnitDisplayName(product.units || 'karton')}
                                 </Button>
                               )}
                             </div>


### PR DESCRIPTION
- Fix Product interface: make units field optional to prevent TypeScript errors
- Fix Netlify configuration: remove conflicting yarn/npm settings
- Remove problematic netlify-build script
- Add fallback values for units field (default to 'karton')
- Ensure build passes locally before deployment